### PR TITLE
Updated compute/storage commandlines

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: versatus
 name: operator
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0
+version: 0.5.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/versatus_common/templates/versatus-services.json.j2
+++ b/roles/versatus_common/templates/versatus-services.json.j2
@@ -7,7 +7,9 @@
       "preSharedKey": "{{ compute_key }}",
       "tlsPrivateKeyFile": "",
       "tlsPublicCertFile": "",
-      "tlsCaCertFile": ""
+      "tlsCaCertFile": "",
+      "exporterAddress": "0.0.0.0",
+      "exporterPort": "9102"
     } ],
     "storage": [ {
       "name": "storage1",
@@ -16,7 +18,9 @@
       "preSharedKey": "{{ storage_key }}",
       "tlsPrivateKeyFile": "",
       "tlsPublicCertFile": "",
-      "tlsCaCertFile": ""
+      "tlsCaCertFile": "",
+      "exporterAddress": "0.0.0.0",
+      "exporterPort": "9103"
     } ],
     "blockchain": [ {
       "name": "blockchain1",
@@ -25,7 +29,9 @@
       "preSharedKey": "{{ blockchain_key }}",
       "tlsPrivateKeyFile": "",
       "tlsPublicCertFile": "",
-      "tlsCaCertFile": ""
+      "tlsCaCertFile": "",
+      "exporterAddress": "0.0.0.0",
+      "exporterPort": "9101"
     } ]
   }
 }

--- a/roles/versatus_compute_node/meta/main.yml
+++ b/roles/versatus_compute_node/meta/main.yml
@@ -24,4 +24,4 @@ dependencies:
       service_name: versatus-compute
       service_user: versatus-compute
       service_executable: "files/versa-compute"
-      service_args: "daemon"
+      service_args: "-c /opt/versatus/etc/versatus-services.json -s compute1 -t compute daemon"

--- a/roles/versatus_storage_node/meta/main.yml
+++ b/roles/versatus_storage_node/meta/main.yml
@@ -24,4 +24,4 @@ dependencies:
       service_name: versatus-storage
       service_user: versatus-storage
       service_executable: "files/versa-storage"
-      service_args: "daemon"
+      service_args: "-c /opt/versatus/etc/versatus-services.json -s storage1 -t storage daemon"


### PR DESCRIPTION
This closes #6 and #7 by updating the command line passed in to the storage agent and compute agent when they're deployed. @ASmithOWL , this shows how we're passing in the path to the config file and keys to find the right object in the config file (as handled by the service_config crate). I can talk more about how all that works and why, if it helps. We'll add some of this to the protocol service at some point as needed, and that'll give us a lot of common infrastructure.